### PR TITLE
Add 2 arguments to camtest.py

### DIFF
--- a/examples/mlx90640_camtest.py
+++ b/examples/mlx90640_camtest.py
@@ -28,10 +28,12 @@ WINDOW_SCALING_FACTOR = 50
 
 # parse command line arguments
 parser = argparse.ArgumentParser()
-parser.add_argument("--windowed", action="store_true",
-                    help="display in a window")
-parser.add_argument("--disable-interpolation", action="store_true",
-                    help="disable interpolation in-between camera pixels")
+parser.add_argument("--windowed", action="store_true", help="display in a window")
+parser.add_argument(
+    "--disable-interpolation",
+    action="store_true",
+    help="disable interpolation in-between camera pixels",
+)
 
 args = parser.parse_args()
 
@@ -43,8 +45,9 @@ pygame.init()
 if not args.windowed:
     screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
 else:
-    screen = pygame.display.set_mode([32*WINDOW_SCALING_FACTOR,
-                                      24*WINDOW_SCALING_FACTOR])
+    screen = pygame.display.set_mode(
+        [32 * WINDOW_SCALING_FACTOR, 24 * WINDOW_SCALING_FACTOR]
+    )
 print(pygame.display.Info())
 
 # the list of colors we can choose from

--- a/examples/mlx90640_camtest.py
+++ b/examples/mlx90640_camtest.py
@@ -5,11 +5,11 @@
 import os
 import math
 import time
+import argparse
 import board
 import busio
 from PIL import Image
 import pygame
-import argparse
 
 import adafruit_mlx90640
 

--- a/examples/mlx90640_camtest.py
+++ b/examples/mlx90640_camtest.py
@@ -30,6 +30,8 @@ WINDOW_SCALING_FACTOR = 50
 parser = argparse.ArgumentParser()
 parser.add_argument("--windowed", action="store_true",
                     help="display in a window")
+parser.add_argument("--disable-interpolation", action="store_true",
+                    help="disable interpolation in-between camera pixels")
 
 args = parser.parse_args()
 
@@ -133,7 +135,8 @@ while True:
     # pixelrgb = [colors[constrain(int(pixel), 0, COLORDEPTH-1)] for pixel in pixels]
     img = Image.new("RGB", (32, 24))
     img.putdata(pixels)
-    img = img.resize((32 * INTERPOLATE, 24 * INTERPOLATE), Image.BICUBIC)
+    if not args.disable_interpolation:
+        img = img.resize((32 * INTERPOLATE, 24 * INTERPOLATE), Image.BICUBIC)
     img_surface = pygame.image.fromstring(img.tobytes(), img.size, img.mode)
     pygame.transform.scale(img_surface.convert(), screen.get_size(), screen)
     pygame.display.update()

--- a/examples/mlx90640_camtest.py
+++ b/examples/mlx90640_camtest.py
@@ -143,6 +143,8 @@ while True:
     img_surface = pygame.image.fromstring(img.tobytes(), img.size, img.mode)
     pygame.transform.scale(img_surface.convert(), screen.get_size(), screen)
     pygame.display.update()
+    if args.windowed:
+        pygame.event.pump()
     print(
         "Completed 2 frames in %0.2f s (%d FPS)"
         % (time.monotonic() - stamp, 1.0 / (time.monotonic() - stamp))

--- a/examples/mlx90640_camtest.py
+++ b/examples/mlx90640_camtest.py
@@ -9,6 +9,7 @@ import board
 import busio
 from PIL import Image
 import pygame
+import argparse
 
 import adafruit_mlx90640
 
@@ -22,11 +23,26 @@ MINTEMP = 20.0
 # high range of the sensor (this will be white on the screen)
 MAXTEMP = 50.0
 
+# if in windowed mode, make the window bigger by this factor
+WINDOW_SCALING_FACTOR = 50
+
+# parse command line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("--windowed", action="store_true",
+                    help="display in a window")
+
+args = parser.parse_args()
+
 # set up display
-os.environ["SDL_FBDEV"] = "/dev/fb0"
-os.environ["SDL_VIDEODRIVER"] = "fbcon"
+if not args.windowed:
+    os.environ["SDL_FBDEV"] = "/dev/fb0"
+    os.environ["SDL_VIDEODRIVER"] = "fbcon"
 pygame.init()
-screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+if not args.windowed:
+    screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+else:
+    screen = pygame.display.set_mode([32*WINDOW_SCALING_FACTOR,
+                                      24*WINDOW_SCALING_FACTOR])
 print(pygame.display.Info())
 
 # the list of colors we can choose from


### PR DESCRIPTION
This adds a parameter to run in windowed mode to allow running the example on a PC running Blinka with the MCP2221A adapter.

Running the example, I felt the need to display the raw output without interpolation so I added a parameter to disable interpolation as well.