### PR TITLE
Handle broken pixels

### DIFF
--- a/adafruit_mlx90640.py
+++ b/adafruit_mlx90640.py
@@ -266,6 +266,11 @@ class MLX90640:  # pylint: disable=too-many-instance-attributes
             )
 
         for pixelNumber in range(768):
+            if self._IsPixelBad(pixelNumber):
+                # print("Fixing broken pixel %d" % pixelNumber)
+                result[pixelNumber] = -273.15
+                continue
+
             ilPattern = pixelNumber // 32 - (pixelNumber // 64) * 2
             chessPattern = ilPattern ^ (pixelNumber - (pixelNumber // 2) * 2)
             conversionPattern = (
@@ -792,6 +797,12 @@ class MLX90640:  # pylint: disable=too-many-instance-attributes
         if pixPosDif > -2 and pixPosDif < 2:
             return True
         if pixPosDif > 30 and pixPosDif < 34:
+            return True
+
+        return False
+
+    def _IsPixelBad(self, pixel):
+        if pixel in self.brokenPixels or pixel in self.outlierPixels:
             return True
 
         return False

--- a/adafruit_mlx90640.py
+++ b/adafruit_mlx90640.py
@@ -749,6 +749,7 @@ class MLX90640:  # pylint: disable=too-many-instance-attributes
         self.ilChessC = ilChessC
 
     def _ExtractDeviatingPixels(self):
+        # pylint: disable=too-many-branches
         pixCnt = 0
 
         while (
@@ -785,11 +786,13 @@ class MLX90640:  # pylint: disable=too-many-instance-attributes
                     raise RuntimeError("Adjacent broken and outlier pixels")
 
     def _UniqueListPairs(self, inputList):
+        # pylint: disable=no-self-use
         for i, listValue1 in enumerate(inputList):
             for listValue2 in inputList[i + 1 :]:
                 yield (listValue1, listValue2)
 
     def _ArePixelsAdjacent(self, pix1, pix2):
+        # pylint: disable=no-self-use, chained-comparison
         pixPosDif = pix1 - pix2
 
         if pixPosDif > -34 and pixPosDif < -30:

--- a/adafruit_mlx90640.py
+++ b/adafruit_mlx90640.py
@@ -792,14 +792,14 @@ class MLX90640:  # pylint: disable=too-many-instance-attributes
                 yield (listValue1, listValue2)
 
     def _ArePixelsAdjacent(self, pix1, pix2):
-        # pylint: disable=no-self-use, chained-comparison
+        # pylint: disable=no-self-use
         pixPosDif = pix1 - pix2
 
-        if pixPosDif > -34 and pixPosDif < -30:
+        if -34 < pixPosDif < -30:
             return True
-        if pixPosDif > -2 and pixPosDif < 2:
+        if -2 < pixPosDif < 2:
             return True
-        if pixPosDif > 30 and pixPosDif < 34:
+        if 30 < pixPosDif < 34:
             return True
 
         return False


### PR DESCRIPTION
I got a mlx90640 with a defective pixel and even though the datasheet says that it's acceptable up to 4, the library was not able to recover and was crashing when trying to calculate the forth root of a negative number:

```
Traceback (most recent call last):
  File "mlx90640_camtest.py", line 124, in <module>
    raise e
  File "mlx90640_camtest.py", line 121, in <module>
    mlx.getFrame(frame)
  File "/home/fgervais/Adafruit_CircuitPython_MLX90640/adafruit_mlx90640.py", line 159, in getFrame
    self._CalculateTo(mlx90640Frame, emissivity, tr, framebuf)
  File "/home/fgervais/Adafruit_CircuitPython_MLX90640/adafruit_mlx90640.py", line 341, in _CalculateTo
    Sx = math.sqrt(math.sqrt(Sx)) * self.ksTo[1]
ValueError: math domain error
```
I added the missing code to handle broken adjacent pixels that had been left out from the library port (noted as TODO) and added the code to detect and "fix" broken pixels when doing the conversion to Celsius.

I must say, I made the dumbest fix but hey, at least it's a valid option recommended by the datasheet :). If I end up needing the more advanced interpolation fixes I'll gladly PR them later on.
