### PR TITLE
Remove usage of max_glyphs with Label

### DIFF
--- a/examples/mlx90640_pygamer.py
+++ b/examples/mlx90640_pygamer.py
@@ -77,10 +77,8 @@ for i in range(number_of_colors):
 # Create the super Group
 group = displayio.Group()
 
-min_label = Label(terminalio.FONT, max_glyphs=10, color=palette[0], x=0, y=110)
-max_label = Label(
-    terminalio.FONT, max_glyphs=10, color=palette[last_color], x=80, y=110
-)
+min_label = Label(terminalio.FONT, color=palette[0], x=0, y=110)
+max_label = Label(terminalio.FONT, color=palette[last_color], x=80, y=110)
 
 # Add all the sub-group to the SuperGroup
 group.append(image_group)


### PR DESCRIPTION
Remove usage of `max_glyphs` now that it has been removed from `Adafruit_CircuitPython_Display_Text`
https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/releases/tag/2.20.0

**Not tested:** I don't have the hardware