### PR TITLE
Fix pylint errors

### DIFF
--- a/examples/mlx90640_camtest.py
+++ b/examples/mlx90640_camtest.py
@@ -85,13 +85,13 @@ def gaussian(x, a, b, c, d=0):
 def gradient(x, width, cmap, spread=1):
     width = float(width)
     r = sum(
-        [gaussian(x, p[1][0], p[0] * width, width / (spread * len(cmap))) for p in cmap]
+        gaussian(x, p[1][0], p[0] * width, width / (spread * len(cmap))) for p in cmap
     )
     g = sum(
-        [gaussian(x, p[1][1], p[0] * width, width / (spread * len(cmap))) for p in cmap]
+        gaussian(x, p[1][1], p[0] * width, width / (spread * len(cmap))) for p in cmap
     )
     b = sum(
-        [gaussian(x, p[1][2], p[0] * width, width / (spread * len(cmap))) for p in cmap]
+        gaussian(x, p[1][2], p[0] * width, width / (spread * len(cmap))) for p in cmap
     )
     r = int(constrain(r * 255, 0, 255))
     g = int(constrain(g * 255, 0, 255))

--- a/examples/mlx90640_pil.py
+++ b/examples/mlx90640_pil.py
@@ -47,13 +47,13 @@ def gaussian(x, a, b, c, d=0):
 def gradient(x, width, cmap, spread=1):
     width = float(width)
     r = sum(
-        [gaussian(x, p[1][0], p[0] * width, width / (spread * len(cmap))) for p in cmap]
+        gaussian(x, p[1][0], p[0] * width, width / (spread * len(cmap))) for p in cmap
     )
     g = sum(
-        [gaussian(x, p[1][1], p[0] * width, width / (spread * len(cmap))) for p in cmap]
+        gaussian(x, p[1][1], p[0] * width, width / (spread * len(cmap))) for p in cmap
     )
     b = sum(
-        [gaussian(x, p[1][2], p[0] * width, width / (spread * len(cmap))) for p in cmap]
+        gaussian(x, p[1][2], p[0] * width, width / (spread * len(cmap))) for p in cmap
     )
     r = int(constrain(r * 255, 0, 255))
     g = int(constrain(g * 255, 0, 255))


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
 ************* Module mlx90640_pil
Error: examples/mlx90640_pil.py:49:8: R1728: Consider using a generator instead 'sum(gaussian(x, p[1][0], p[0] * width, width / (spread * len(cmap))) for p in cmap)' (consider-using-generator)
Error: examples/mlx90640_pil.py:52:8: R1728: Consider using a generator instead 'sum(gaussian(x, p[1][1], p[0] * width, width / (spread * len(cmap))) for p in cmap)' (consider-using-generator)
Error: examples/mlx90640_pil.py:55:8: R1728: Consider using a generator instead 'sum(gaussian(x, p[1][2], p[0] * width, width / (spread * len(cmap))) for p in cmap)' (consider-using-generator)
************* Module mlx90640_camtest
Error: examples/mlx90640_camtest.py:87:8: R1728: Consider using a generator instead 'sum(gaussian(x, p[1][0], p[0] * width, width / (spread * len(cmap))) for p in cmap)' (consider-using-generator)
Error: examples/mlx90640_camtest.py:90:8: R1728: Consider using a generator instead 'sum(gaussian(x, p[1][1], p[0] * width, width / (spread * len(cmap))) for p in cmap)' (consider-using-generator)
Error: examples/mlx90640_camtest.py:93:8: R1728: Consider using a generator instead 'sum(gaussian(x, p[1][2], p[0] * width, width / (spread * len(cmap))) for p in cmap)' (consider-using-generator)
```